### PR TITLE
Simplify Tanimoto kernel.

### DIFF
--- a/gprotorch/kernels/fingerprint_kernels/base_fingerprint_kernel.py
+++ b/gprotorch/kernels/fingerprint_kernels/base_fingerprint_kernel.py
@@ -58,7 +58,7 @@ class BitDistance(torch.nn.Module):
         # Branch for Tanimoto metric
         if metric == "tanimoto":
             res = batch_tanimoto_sim(x1, x2)
-            res.clamp_min_(0)
+            res.clamp_min_(0)  # zero out negative values
             return self._postprocess(res) if postprocess else res
         else:
             raise RuntimeError(

--- a/gprotorch/kernels/fingerprint_kernels/base_fingerprint_kernel.py
+++ b/gprotorch/kernels/fingerprint_kernels/base_fingerprint_kernel.py
@@ -8,15 +8,34 @@ from gpytorch.kernels.kernel import default_postprocess_script
 import torch
 
 
+def batch_tanimoto_sim(
+    x1: torch.Tensor, x2: torch.Tensor, eps: float = 1e-6
+) -> torch.Tensor:
+    """
+    Tanimoto between two batched tensors, across last 2 dimensions.
+
+    eps argument ensures numerical stability if all zero tensors are added.
+    """
+    # Tanimoto distance is proportional to (<x, y>) / (||x||^2 + ||y||^2 - <x, y>) where x and y are bit vectors
+    assert x1.ndim >= 2 and x2.ndim >= 2
+    dot_prod = torch.matmul(x1, torch.transpose(x2, -1, -2))
+    x1_sum = torch.sum(x1**2, dim=-1, keepdims=True)
+    x2_sum = torch.sum(x2**2, dim=-1, keepdims=True)
+    return (dot_prod + eps) / (
+        eps + x1_sum + torch.transpose(x2_sum, -1, -2) - dot_prod
+    )
+
+
 class BitDistance(torch.nn.Module):
     r"""
     Distance module for bit vector test_kernels.
     """
+
     def __init__(self, postprocess_script=default_postprocess_script):
         super().__init__()
         self._postprocess = postprocess_script
 
-    def _sim(self, x1, x2, postprocess, x1_eq_x2=False, metric='tanimoto'):
+    def _sim(self, x1, x2, postprocess, x1_eq_x2=False, metric="tanimoto"):
         r"""
         Computes the similarity between x1 and x2
 
@@ -36,59 +55,38 @@ class BitDistance(torch.nn.Module):
             (:class:`Tensor`, :class:`Tensor) corresponding to the similarity matrix between `x1` and `x2`
         """
 
-        # Extend this list when including new metrics
-
-        if metric not in ['tanimoto']:
-            raise RuntimeError('Similarity metric not supported. Available options are \'tanimoto\'')
-
         # Branch for Tanimoto metric
-        if metric == 'tanimoto':
-
-            # Tanimoto distance is proportional to (<x, y>) / (||x||^2 + ||y||^2 - <x, y>) where x and y are bit vectors
-
-            x1_norm = x1.pow(2).sum(dim=-1, keepdim=True)  # Compute the squared L2-norm of each datapoint
-            if x1_eq_x2 and not x1.requires_grad and not x2.requires_grad:
-                x2_norm = x1_norm
-            else:
-                x2_norm = x2.pow(2).sum(dim=-1, keepdim=False)
-
-            # The following code works for both the batch and non-batch cases
-            cross_product = x1.matmul(x2.transpose(-2, -1))
-
-            # Analogue of denominator in Tanimoto formula
-            denominator = x1_norm + x2_norm.squeeze(-1) - cross_product
-
-            res = (cross_product/denominator)
-
-            # if x1 and x2 are equal than the Tanimoto similarity is 1
-            if x1_eq_x2 and not x1.requires_grad and not x2.requires_grad:
-                res.diagonal(dim1=-2, dim2=-1).fill_(1)
-
-            # Zero out negative values
+        if metric == "tanimoto":
+            res = batch_tanimoto_sim(x1, x2)
             res.clamp_min_(0)
             return self._postprocess(res) if postprocess else res
+        else:
+            raise RuntimeError(
+                "Similarity metric not supported. Available options are 'tanimoto'"
+            )
 
 
 class BitKernel(Kernel):
     r"""
-    Base class for test_kernels that operate on bit or count vectors such as ECFP fingerprints or RDKit fragments.
+     Base class for test_kernels that operate on bit or count vectors such as ECFP fingerprints or RDKit fragments.
 
-    In the typical use case, test_kernels inheriting from this class will specify a similarity metric such as Tanimoto,
-    MinMax etc.
+     In the typical use case, test_kernels inheriting from this class will specify a similarity metric such as Tanimoto,
+     MinMax etc.
 
-   .. note::
+    .. note::
 
-    This kernel does not have an `outputscale` parameter. To add a scaling parameter,
-    decorate this kernel with a :class:`gpytorch.test_kernels.ScaleKernel`.
+     This kernel does not have an `outputscale` parameter. To add a scaling parameter,
+     decorate this kernel with a :class:`gpytorch.test_kernels.ScaleKernel`.
 
-    This base :class:`BitKernel` class does not include a lengthscale parameter
-    :math:`\Theta`, in contrast to many common kernel functions.
+     This base :class:`BitKernel` class does not include a lengthscale parameter
+     :math:`\Theta`, in contrast to many common kernel functions.
 
-    Base Attributes:
-    :attr:`metric` (str):
-        The similarity metric to use. One of ['tanimoto'].
+     Base Attributes:
+     :attr:`metric` (str):
+         The similarity metric to use. One of ['tanimoto'].
     """
-    def __init__(self, metric='', **kwargs):
+
+    def __init__(self, metric="", **kwargs):
         super().__init__(**kwargs)
         self.metric = metric
 
@@ -136,9 +134,14 @@ class BitKernel(Kernel):
         res = None
 
         # Cache the Distance object or else JIT will recompile every time
-        if not self.distance_module or self.distance_module._postprocess != dist_postprocess_func:
+        if (
+            not self.distance_module
+            or self.distance_module._postprocess != dist_postprocess_func
+        ):
             self.distance_module = BitDistance(dist_postprocess_func)
 
-        res = self.distance_module._sim(x1, x2, postprocess, x1_eq_x2, self.metric)
+        res = self.distance_module._sim(
+            x1, x2, postprocess, x1_eq_x2, self.metric
+        )
 
         return res

--- a/gprotorch/kernels/fingerprint_kernels/tanimoto_kernel.py
+++ b/gprotorch/kernels/fingerprint_kernels/tanimoto_kernel.py
@@ -3,43 +3,56 @@ Tanimoto Kernel. Operates on representations including bit vectors e.g. Morgan/E
 RDKit fragment features.
 """
 
+import torch
 import gpytorch
 
-from gprotorch.kernels.fingerprint_kernels.base_fingerprint_kernel import BitKernel
+from gprotorch.kernels.fingerprint_kernels.base_fingerprint_kernel import (
+    BitKernel,
+)
 
 
 class TanimotoKernel(BitKernel):
     r"""
-    Computes a covariance matrix based on the Tanimoto kernel
-    between inputs :math:`\mathbf{x_1}` and :math:`\mathbf{x_2}`:
+     Computes a covariance matrix based on the Tanimoto kernel
+     between inputs :math:`\mathbf{x_1}` and :math:`\mathbf{x_2}`:
 
-    .. math::
+     .. math::
 
-   \begin{equation*}
-    k_{\text{Tanimoto}}(\mathbf{x}, \mathbf{x'}) = \frac{\langle\mathbf{x},
-    \mathbf{x'}\rangle}{\left\lVert\mathbf{x}\right\rVert^2 + \left\lVert\mathbf{x'}\right\rVert^2 -
-    \langle\mathbf{x}, \mathbf{x'}\rangle}
-   \end{equation*}
+    \begin{equation*}
+     k_{\text{Tanimoto}}(\mathbf{x}, \mathbf{x'}) = \frac{\langle\mathbf{x},
+     \mathbf{x'}\rangle}{\left\lVert\mathbf{x}\right\rVert^2 + \left\lVert\mathbf{x'}\right\rVert^2 -
+     \langle\mathbf{x}, \mathbf{x'}\rangle}
+    \end{equation*}
 
-   .. note::
+    .. note::
 
-    This kernel does not have an `outputscale` parameter. To add a scaling parameter,
-    decorate this kernel with a :class:`gpytorch.test_kernels.ScaleKernel`.
+     This kernel does not have an `outputscale` parameter. To add a scaling parameter,
+     decorate this kernel with a :class:`gpytorch.test_kernels.ScaleKernel`.
 
-    Example:
-        >>> x = torch.randint(0, 2, (10, 5))
-        >>> # Non-batch: Simple option
-        >>> covar_module = gpytorch.kernels.ScaleKernel(TanimotoKernel())
-        >>> covar = covar_module(x)  # Output: LazyTensor of size (10 x 10)
-        >>>
-        >>> batch_x = torch.randint(0, 2, (2, 10, 5))
-        >>> # Batch: Simple option
-        >>> covar_module = gpytorch.kernels.ScaleKernel(TanimotoKernel())
-        >>> covar = covar_module(batch_x)  # Output: LazyTensor of size (2 x 10 x 10)
+     Example:
+         >>> x = torch.randint(0, 2, (10, 5))
+         >>> # Non-batch: Simple option
+         >>> covar_module = gpytorch.kernels.ScaleKernel(TanimotoKernel())
+         >>> covar = covar_module(x)  # Output: LazyTensor of size (10 x 10)
+         >>>
+         >>> batch_x = torch.randint(0, 2, (2, 10, 5))
+         >>> # Batch: Simple option
+         >>> covar_module = gpytorch.kernels.ScaleKernel(TanimotoKernel())
+         >>> covar = covar_module(batch_x)  # Output: LazyTensor of size (2 x 10 x 10)
     """
+
+    is_stationary = False
+    has_lengthscale = False
+
     def __init__(self, **kwargs):
         super(TanimotoKernel, self).__init__(**kwargs)
-        self.metric = 'tanimoto'
+        self.metric = "tanimoto"
 
-    def forward(self, x1, x2, **params):
-        return self.covar_dist(x1, x2, **params)
+    def forward(self, x1, x2, diag=False, **params):
+        if diag:
+            assert x1.size() == x2.size() and torch.equal(x1, x2)
+            return torch.ones(
+                *x1.shape[:-2], x1.shape[-2], dtype=x1.dtype, device=x1.device
+            )
+        else:
+            return self.covar_dist(x1, x2, **params)


### PR DESCRIPTION
I made some simplifications to the Tanimoto kernel.

1. Added in my batch Tanimoto similarity code, which also works if for some reason you feed in a vector of all zeros.
2. Remove some redundant logic. For example, there was some stuff about gradients in the Tanimoto code. Tanimoto is a discrete kernel, I think you should never be computing a gradient. Also removed some redundancy in the check for supported metrics.
3. Added an extra option for Tanimoto kernels to support just returning the diagonal (which is just a tensor of ones).

Also ran `black` formatting.