### PR TITLE
Add the "minmax" kernel

### DIFF
--- a/gauche/kernels/fingerprint_kernels/base_fingerprint_kernel.py
+++ b/gauche/kernels/fingerprint_kernels/base_fingerprint_kernel.py
@@ -37,11 +37,6 @@ def minmax_sim(
     (where || is the L1 norm)
     """
 
-    # Check dimension is correct
-    assert x1.ndim == 2
-    assert x2.ndim == 2
-    assert x1.shape[1] == x2.shape[1]
-
     # Compute l1 norms
     x1_norm = torch.sum(x1, dim=-1, keepdim=True)
     x2_norm = torch.sum(x2, dim=-1, keepdim=True)

--- a/gauche/kernels/fingerprint_kernels/tanimoto_kernel.py
+++ b/gauche/kernels/fingerprint_kernels/tanimoto_kernel.py
@@ -1,6 +1,6 @@
 """
-Tanimoto Kernel. Operates on representations including bit vectors e.g. Morgan/ECFP6 fingerprints count vectors e.g.
-RDKit fragment features.
+Tanimoto Kernel. Operates on discrete or real-valued representations including bit vectors
+(e.g. Morgan/ECFP6 fingerprints) and count vectors (e.g. RDKit fragment features).
 """
 
 import gpytorch
@@ -22,6 +22,9 @@ class TanimotoKernel(BitKernel):
      \mathbf{x'}\rangle}{\left\lVert\mathbf{x}\right\rVert^2 + \left\lVert\mathbf{x'}\right\rVert^2 -
      \langle\mathbf{x}, \mathbf{x'}\rangle}
     \end{equation*}
+
+    This kernel is positive-definite for all real-valued inputs
+    (see https://arxiv.org/abs/2306.14809).
 
     .. note::
 
@@ -55,3 +58,21 @@ class TanimotoKernel(BitKernel):
             )
         else:
             return self.covar_dist(x1, x2, **params)
+
+
+class MinMaxKernel(TanimotoKernel):
+    r"""
+    A continuous extension to the Tanimoto kernel on binary fingerprints.
+
+     .. math::
+
+    \begin{equation*}
+     k_{\text{MinMax}}(\mathbf{x}, \mathbf{x'}) = \frac{\sum_i \min(x_i, x'_i)}{\sum_i \max(x_i, x'_i)}
+    \end{equation*}
+
+    ..
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.metric = "minmax"


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes

This PR provides a memory-efficient implementation for the minmax kernel from my personal BO repo.

It uses a formulation from Ioffe (2010) that allows `torch.cdist` to be used instead of directly computing mins/maxes.

#### What testing did you do to verify the changes in this PR?

None: unfortunately I could not get the environment to build properly on my machine so I could not run the tests. Maybe you can run them if you have a pre-built environment which works? I think the environment file in the main repository is out of date...

#### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at https://leojklarner.github.io/gauche/.
-->

- [ ] Added a note about the modification or contribution to the `./CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./gauche/tests/*` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `./notebooks/` (if applicable)
- [ ] Ran `python -m py.test tests/` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `python -m py.test tests/kernels/test_graph_kernels.py`)
- [ ] Checked for style issues by running `black .` and `isort .`


<!--
We value all user contributions, no matter how minor they are.

Thanks for contributing!
-->